### PR TITLE
Adding support for StartPage.com

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -145,6 +145,9 @@ async function getAnswer(question: string, callback) {
 
         if (event.status === 429)
           cardStatus.value = 'TooManyRequests'
+        
+        if (event.status !== 200)
+          cardStatus.value = 'GeneralError'
 
         if (getUserscriptManager() !== 'Tampermonkey') {
           if (event.response)
@@ -160,6 +163,8 @@ async function getAnswer(question: string, callback) {
 
 function getQuestion() {
   switch (getWebsite().name) {
+    case 'startpage':
+      return document.getElementById("q").value;
     case 'baidu':
       return new URL(window.location.href).searchParams.get('wd')
     case 'deepl': {

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@ enum CardStatus {
   'PleaseLogin',
   'UnknownError',
   'TooManyRequests',
+  'GeneralError',
 }
 const answer = ref(null)
 const cardStatus = ref<CardStatus>()

--- a/src/App.vue
+++ b/src/App.vue
@@ -141,14 +141,15 @@ async function getAnswer(question: string, callback) {
           removeAccessToken()
           cardStatus.value = 'PleaseLogin'
         }
+                
+        if (event.status !== 200)
+          cardStatus.value = 'GeneralError'
+          
         if (event.status === 403)
           cardStatus.value = 'BlockedByCloudflare'
 
         if (event.status === 429)
           cardStatus.value = 'TooManyRequests'
-        
-        if (event.status !== 200)
-          cardStatus.value = 'GeneralError'
 
         if (getUserscriptManager() !== 'Tampermonkey') {
           if (event.response)

--- a/src/components/ChatGPTCard.vue
+++ b/src/components/ChatGPTCard.vue
@@ -25,4 +25,7 @@ defineProps(['status', 'answer'])
   <div v-else-if="status === 'TooManyRequests'" class="chat-gpt-container">
     <p>{{ i18n('tooManyRequests') }}</p>
   </div>
+    <div v-else-if="status === 'GeneralError'" class="chat-gpt-container">
+    <p>{{ i18n('generalError') }}</p>
+  </div>
 </template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,9 @@ function initUI(container: HTMLDivElement) {
     case 'duckduckgo':
       duckduckgoInjectContainer(container)
       break
+    case 'startpage':
+      startpageInjectContainer(container)
+      break
     case 'deepl':
       deeplInjectContainer(container)
       break
@@ -84,6 +87,11 @@ function initUI(container: HTMLDivElement) {
   }
   function duckduckgoInjectContainer(container: HTMLDivElement) {
     const ChatGPTCard: Element = document.getElementsByClassName('results--sidebar')[0]
+    ChatGPTCard.prepend(container)
+  }
+  function startpageInjectContainer(container: HTMLDivElement) {
+    const ChatGPTCard: Element = document.getElementsByClassName('sidebar-results')[0]
+    container2.classList.add("sx-kp");
     ChatGPTCard.prepend(container)
   }
   function deeplInjectContainer(container: HTMLDivElement) {

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -18,6 +18,7 @@ export function config(lang: string) {
         networkException: '网络异常，请刷新页面。',
         containerPosition: '容器位置 - 侧面(1)/顶部(0): ',
         chatGPTTranslate: 'ChatGPT 翻译',
+        generalError: "NEEDS TRANSLATING: Error... Failed to get valid response from ChatGPT",
       }
       break
     case 'zh-TW':
@@ -31,6 +32,7 @@ export function config(lang: string) {
         networkException: '網路異常，請刷新頁面。',
         containerPosition: '容器位置 - 側面(1)/頂部(0):',
         chatGPTTranslate: 'ChatGPT 翻譯',
+        generalError: "NEEDS TRANSLATING: Error... Failed to get valid response from ChatGPT",
       }
       break
     default:
@@ -43,6 +45,7 @@ export function config(lang: string) {
         networkException: 'Network exception, please refresh the page.',
         containerPosition: 'Container Position - Side(1)/Top(0): ',
         chatGPTTranslate: 'ChatGPT Translate',
+        generalError: "Error... Failed to get valid response from ChatGPT",
       }
   }
   return result

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,6 +16,8 @@ export function getWebsite() {
       return configRequestImmediately('baidu')
     case 'duckduckgo.com':
       return configRequestImmediately('duckduckgo')
+    case 'www.startpage.com':
+      return configRequestImmediately('startpage')
     case 'www.deepl.com':
       return configRequestAfterClickButton('deepl')
     default:


### PR DESCRIPTION
I like this, but it does not offer support for startpage.com, my primary search engine preference. I added working functionality to this in tampermonkey, so I took those changes and applied them here as well. This will need testing, as I have not tested these changes in git hub, but I have tested the changes in tampermonkey. You can see the tampermonkey file that I am using here:
[ChatGPT Search.user.txt](https://github.com/zhengbangbo/chat-gpt-userscript/files/11128416/ChatGPT.Search.user.txt)

I also added a general error message for any status that isn't 200 so you know it responded with an error code, instead of thinking it's taking a while to respond. That was an issue I ran into.

The only change I did not apply to the git hub version that I did do in the tampermonkey version is I removed the extra spaces at the beginning of the answer. It added 2 \n at the beginning and it did not look good, so I removed them.